### PR TITLE
bankai@8, fix letter spacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -334,12 +334,12 @@ function Logo (text) {
   var prefix = css`
     :host .c,
     :host .h,
-    :host .o { letter-spacing: -0.25em }
+    :host .o { letter-spacing: -0.05em }
 
     @media screen and (min-width: 30em) {
-      :host .c { letter-spacing: -0.25em }
-      :host .h { letter-spacing: -0.1em }
-      :host .o { letter-spacing: 0.05em }
+      :host .c { letter-spacing: -0.05em }
+      :host .h { letter-spacing: 0.05em }
+      :host .o { letter-spacing: 0.15em }
     }
   `
   return html`
@@ -348,7 +348,7 @@ function Logo (text) {
       <span className="c">c</span>
       <span className="h">h</span>
       <span className="o">o</span>
-      o
+      <span>o</span>
       <div class="pl3 dib vhs-right vhs-delay-3">🚂🚋🚋🚋</div>
     </h1>
     <h2 class="f2-l dib vhs-bottom vhs-delay-4 ttu ma0">

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "vhs": "^0.2.0"
   },
   "devDependencies": {
-    "bankai": "^6.1.1",
+    "bankai": "^8.1.1",
     "brfs": "^1.4.3",
     "clean-css": "^3.4.23",
     "concat-stream": "^1.6.0",


### PR DESCRIPTION
Upping bankai to v8 to get the later yo-yoify version, re-adjusting the CSS fixes the letter spacing issue at the top of the site. Bankai build/start render the same now and no visible difference to previous bankai version (6).

![screen shot 2017-08-12 at 18 30 01](https://user-images.githubusercontent.com/18026180/29242994-2301590a-7f8d-11e7-96b2-46f317735b9b.png)