### PR TITLE
prevent editing `npm i choo` text

### DIFF
--- a/components/navigation.js
+++ b/components/navigation.js
@@ -205,6 +205,7 @@ function renderNpm () {
   return html`
     <input
       type="text"
+      readonly
       value="npm i choo"
       class="psr fs1 db tar fc-black"
       style="width: 5.5rem"


### PR DESCRIPTION
by marking it `readonly` you can still select and copy it easily but you
can't edit it anymore. because i HAT E FUN

(and because I thought it was a link so it was confusing when I clicked
it to find that it was a text input)