### PR TITLE
Update "Listening For Route Changes" section

### DIFF
--- a/content/docs/routing/index.md
+++ b/content/docs/routing/index.md
@@ -336,9 +336,9 @@ var choo = require('choo')
 var app = choo()
 
 var app = choo()
-app.use((state, emitter) => {            // 1.
-  emitter.on('navigate', (route) => {    // 2.
-    console.log(`Navigated to ${route}`) // 3.
+app.use((state, emitter) => {                  // 1.
+  emitter.on('navigate', () => {               // 2.
+    console.log(`Navigated to ${state.route}`) // 3.
   })
 })
 ```


### PR DESCRIPTION
the 'navigate' doesn't receive any argument at the moment,
but the current route can still be determined by looking at
the state. this commit reflects that idea in the docs.