### PR TITLE
Darker comments, fixes #50

### DIFF
--- a/design/syntax.js
+++ b/design/syntax.js
@@ -26,7 +26,7 @@ module.exports = `
   }
 
   .hljs-comment {
-    color: ${options.colors.grey_25};
+    color: ${options.colors.grey_75};
   }
 
   .hljs-string,


### PR DESCRIPTION
Make comments a few shades darker so they are more easily noticeable:

![image](https://user-images.githubusercontent.com/1006268/36783940-fc8215ce-1c7d-11e8-841b-0f4db9cb3067.png)

Happy to use a different colour if that'd be prettier :)