### PR TITLE
Fix StateMachine Doc

### DIFF
--- a/content/docs/state-machines/index.md
+++ b/content/docs/state-machines/index.md
@@ -119,15 +119,15 @@ _note: the `class` notation here is for brevity. It's the idea that matters more
 than the implementation. So feel free to write this down however you prefer!_
 
 ```js
-export class StateMachine {
+class StateMachine {
   constructor (initialState, transitions) {
     this.state = initialState
     this.transitions = transitions
   }
 
-  next (transition) {
+  transition (transitionName) {
     var nextState = this.transitions[this.state][transition]
-    if (!nextState) throw new Error(`invalid: ${this.state} -> ${transition}`)
+    if (!nextState) throw new Error(`invalid: ${this.state} -> ${transitionName}`)
     this.state = nextState
   }
 }

--- a/content/docs/state-machines/index.md
+++ b/content/docs/state-machines/index.md
@@ -74,9 +74,9 @@ The first step is to write down our states and transitions:
 
 ```js
 var transitions = {
-  green: { timer: orange },
-  orange: { timer: red },
-  red: { timer: green }
+  green: { timer: 'orange' },
+  orange: { timer: 'red' },
+  red: { timer: 'green' }
 }
 ```
 
@@ -142,9 +142,9 @@ Now that we have all our individual bits, let's combine it all together:
 
 ```js
 var machine = new StateMachine('green', {
-  green: { timer: orange },
-  orange: { timer: red },
-  red: { timer: green }
+  green: { timer: 'orange' },
+  orange: { timer: 'red' },
+  red: { timer: 'green' }
 })
 
 machine.transition('timer')


### PR DESCRIPTION
This PR fixes #64 

Changes:
* Turn `timer` values into strings
* Rename `stateMachine`'s method to match the rest of the doc
* Remove `export` from `stateMachine` class

My reasoning for the third item: `export` seemed extraneous in this context. The doc is trying to explain the concept of a finite state machine, and it seems unnecessary to add the mental trappings of the module system (at least in this section).

It also makes the code example harder to run (until ES6 is supported) in a browser console or Node.js.

That being said, If `export` should be included, I would suggest adding  an `import` to the next code block under [**Combining Data & State**](https://github.com/choojs/website/blob/master/content/docs/state-machines/index.md#combining-data--state).
```js
import StateMachine from 'state-machine.js'

var machine = new StateMachine('green', {
  green: { timer: orange },
  orange: { timer: red },
  red: { timer: green }
})

machine.transition('timer')
console.log(machine.state) // => 'orange'

machine.transition('timer')
console.log(machine.state) // => 'red'

machine.transition('timer')
console.log(machine.state) // => 'green'
```